### PR TITLE
throw RangeError when skippedElements > Number.MAX_SAFE_INTEGER

### DIFF
--- a/spec.emu
+++ b/spec.emu
@@ -25,6 +25,9 @@ copyright: false
     1. If _toSkip_ &lt; *-0*<sub>𝔽</sub>, then
       1. Let _error_ be ThrowCompletion(a newly created *RangeError* object).
       1. Return ? IteratorClose(_iterated_, _error_).
+    1. If _toSkip_ is finite and _toSkip_ > 𝔽(2<sup>53</sup> - 1), then
+      1. Let _error_ be ThrowCompletion(a newly created *RangeError* object).
+      1. Return ? IteratorClose(_iterated_, _error_).
     1. Let _skipped_ be *+0*<sub>𝔽</sub>.
     1. Set _iterated_ to ? GetIteratorDirect(_O_).
     1. Repeat,

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ function includes<T>(this: IterableIterator<T>, searchElement: T, skippedElement
     }
     toSkip = skippedElements as number;
   }
-  if (toSkip < 0) {
+  if (toSkip < 0 || Number.isFinite(toSkip) && toSkip > Number.MAX_SAFE_INTEGER) {
     try { this.return?.(); } catch {}
     throw new RangeError;
   }

--- a/test/index.mjs
+++ b/test/index.mjs
@@ -180,6 +180,10 @@ test('skipped elements', async t => {
     assert.equal([4, 5, 6, 7].values().includes(7, 5), false);
   });
 
+  await test('Number.MAX_SAFE_INTEGER', async t => {
+    assert.equal([0].values().includes(0, Number.MAX_SAFE_INTEGER), false);
+  });
+
   await test('positive non-integral', async t => {
     assert.throws(() => {
       [].values().includes(0, 0.1);
@@ -214,6 +218,15 @@ test('skipped elements', async t => {
     assert.throws(() => {
       [].values().includes(0, { valueOf() { return 0; } });
     }, TypeError);
+  });
+
+  await test('greater than Number.MAX_SAFE_INTEGER', async t => {
+    assert.throws(() => {
+      [].values().includes(0, Number.MAX_SAFE_INTEGER + 1);
+    }, RangeError);
+    assert.throws(() => {
+      [].values().includes(0, Number.MAX_SAFE_INTEGER + 3);
+    }, RangeError);
   });
 });
 


### PR DESCRIPTION
Fixes #12.